### PR TITLE
fix: Support malformed macro_rules!

### DIFF
--- a/scripts/parser.codegen.ts
+++ b/scripts/parser.codegen.ts
@@ -49,7 +49,7 @@ const KEYWORD_SCANNER_SPEC = [
 	// # Not keywords
 	{ name: "Underscore", match: "_" },
 	{ name: "RawIdentifier", match: "r#", eval: on_match_RawIdentifier },
-	{ name: "macro_rules!", match: "macro_rules", eval: `if (uc_next_match(${CharCode(33)})) { return ${Keyword("macro_rules!")}; }` },
+	{ name: "macro_rules!", match: "macro_rules", eval: `if (will_actually_read_macro_rules()) { return ${Keyword("macro_rules!")}; }` },
 
 	{ name: "StringLiteral", match: "b", eval: ` if (will_actually_read_bString()) { return ${Keyword("StringLiteral")}; }` },
 	{ name: "StringLiteral", match: "br", eval: `if (will_actually_read_rString()) { return ${Keyword("StringLiteral")}; }` },

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -11,10 +11,21 @@ import {
 	print_string,
 	strChar,
 	urlAt,
+	__SET_PARSER_ERROR_MNGR,
 } from "../utils/common";
 import { createCustomError } from "../utils/debug";
 import { Located, Node, NodeType, NTMap } from "./nodes";
-import { check_ahead, currChar, GET_KEYWORD_NAME, GET_LENGTH, GET_POSITION, GET_SOURCEFILEPATH, GET_SOURCETEXT, nStep } from "./state";
+import {
+	check_ahead,
+	currChar,
+	GET_KEYWORD_NAME,
+	GET_LENGTH,
+	GET_POSITION,
+	GET_SOURCEFILEPATH,
+	GET_SOURCETEXT,
+	IS_PARSING,
+	nStep,
+} from "./state";
 import { devonly_getDebugState } from "./state/debug";
 import { Keyword, kwTree } from "./state/scanner";
 
@@ -133,6 +144,10 @@ export namespace exit {
 		expected();
 	}
 }
+
+__SET_PARSER_ERROR_MNGR(function (msg, ctx) {
+	if (IS_PARSING()) exit(msg, ...ctx);
+});
 
 // prettier-ignore
 export function assert(predicate: boolean, err?: string, ...ctx: any[]): asserts predicate {

--- a/src/parser/state/scanner.ts
+++ b/src/parser/state/scanner.ts
@@ -1,4 +1,5 @@
 import {
+	check_ahead,
 	currChar,
 	edgecase_stepback,
 	ES_ctx_exceptStructFormExpression,
@@ -25,6 +26,7 @@ import { is_XID_Continue, is_XID_Start } from "../../utils/enum";
 import { is_UNICODE_XID_Start } from "../../utils/unicode";
 import { assert, exit } from "../error";
 import { PRCD, TK } from "../nodes";
+import { skip_whitespace } from "./whitespace";
 
 // <codegen> edits discriminants
 export const enum RHS {
@@ -249,6 +251,13 @@ function will_actually_read_bString() {
 		default:
 			return false; // boop
 	}
+}
+
+function will_actually_read_macro_rules() {
+	// macro_rules••••••••••••••••
+	//           ^- You are here
+
+	return uc_next_match(CharCode["!"]) || check_ahead(() => (skip_whitespace(), match(CharCode["!"])));
 }
 
 // #valid_identifier_keywords
@@ -587,7 +596,7 @@ export function kwTree(): Keyword {
 										uc_next_match(CharCode["e"]) &&
 										uc_next_match(CharCode["s"])
 									) {
-										if (uc_next_match(CharCode["!"])) {
+										if (will_actually_read_macro_rules()) {
 											return Keyword["macro_rules!"];
 										}
 									}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -32,7 +32,15 @@ type anyfunction<A extends any[] = unknown[], R = unknown> = (...args: A) => R;
 type objlike = object | anyfunction;
 type anymap<K extends unknown = unknown, V extends unknown = unknown> = K extends objlike ? Map<K, V> | WeakMap<K, V> : Map<K, V>;
 
+let __parser_maybe_exit: ParserMaybeExit;
+type ParserMaybeExit = (message: string, ctx: any[]) => void | never;
+export function __SET_PARSER_ERROR_MNGR(_maybe_exit: ParserMaybeExit) {
+	__DEV__: assert(!__parser_maybe_exit);
+	__parser_maybe_exit = _maybe_exit;
+}
+
 export function exit(message: string, ...ctx: any[]): never {
+	__parser_maybe_exit?.(message, ctx);
 	if (ctx.length > 0) console.log("Error context:", { ...ctx });
 	throw createCustomError({ message });
 }

--- a/tests/output/macro/macro.item.p.rs
+++ b/tests/output/macro/macro.item.p.rs
@@ -1,3 +1,5 @@
+macro_rules ! spaced {}                                                                                                                   /*
+macro_rules•!•spaced•{}    MacroRulesDeclaration                                                                                          */
 macro_rules! brace { () => { } ; }                                                                                                        /*
 macro_rules!•brace•{•()•=>•{•}•;•}    MacroRulesDeclaration
                      ()•=>•{•}        MacroRuleDeclaration                                                                                */
@@ -38,8 +40,8 @@ pub(crate)                                                   PubSpecifier
                                                  $arg        McIdentifier                                                                 */
 
 // Discarded Nodes: 0
-// Parsed Nodes: 45
-// state_rollbacks: 5
-// Total '.charCodeAt()' calls: 351 (23% re-reads)
-// Unnecessary 'skip_whitespace()' calls: 14
+// Parsed Nodes: 47
+// state_rollbacks: 8
+// Total '.charCodeAt()' calls: 388 (25% re-reads)
+// Unnecessary 'skip_whitespace()' calls: 16
 // source: "../../samples/macro/macro.item.rs"

--- a/tests/output/macro/macro.transform.p.rs
+++ b/tests/output/macro/macro.transform.p.rs
@@ -15245,5 +15245,5 @@ macro•complex_nonterminal($nt_item:•item)•{↲    <MacroDeclaration>
 // Parsed Nodes: 16382
 // state_rollbacks: 1
 // Total '.charCodeAt()' calls: 108457 (11% re-reads)
-// Unnecessary 'skip_whitespace()' calls: 5426
+// Unnecessary 'skip_whitespace()' calls: 5428
 // source: "../../samples/macro/macro.transform.rs"

--- a/tests/samples/macro/macro.item.rs
+++ b/tests/samples/macro/macro.item.rs
@@ -1,3 +1,4 @@
+macro_rules ! spaced {}
 macro_rules! brace { () => { } ; }
 macro_rules! bracket[() => { } ;];
 macro_rules! paren(() => { } ;);


### PR DESCRIPTION
- fix: parse malformed macro_rules!
- fix: throw all errors as Parser Errors